### PR TITLE
Add first blog post of 2026

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+- **Dev server:** `npm run dev`
+- **Build:** `npm run build`
+- **Lint:** Build runs ESLint automatically (no separate lint script)
+
+There are no tests configured.
+
+## Architecture
+
+Next.js 13 personal portfolio site using SSG (Static Site Generation) with TypeScript and TailwindCSS 2.0.
+
+### Pages
+
+Pages live in `pages/` using Next.js pages router. The home page (`index.tsx`) imports `blog.tsx`, `contact.tsx`, and `projects.tsx` as components rendered inline — they are both standalone pages and homepage sections.
+
+### Blog System
+
+Blog posts are markdown files in `content/blog/` with YAML frontmatter (`title`, `date`, `tags`). The dynamic route `pages/blog/[slug].tsx` generates static pages from filenames using `getStaticPaths`/`getStaticProps`. Frontmatter is parsed with regex (not a library).
+
+**Important:** The blog listing in `pages/blog.tsx` is **hardcoded** — adding a new post requires manually adding a `<li>` entry there in addition to creating the markdown file.
+
+Tags render as coloured pills with a colour map in `[slug].tsx` (`tagColors` object). New tag names need a colour entry or they fall back to gray.
+
+Markdown is rendered with `react-markdown` + `remark-gfm` + `remark-breaks` (line breaks render without needing double spaces).
+
+### Blog images
+
+Blog post images are stored in `public/blog/<slug>/` and referenced in markdown as `/blog/<slug>/image.png`.
+
+## Code Style
+
+- **Prettier:** tabs, no semicolons, single quotes, 100 char print width, trailing commas (es5)
+- **ESLint:** strict TypeScript, React hooks, jsx-a11y accessibility rules, prettier integration
+- **Emojis in JSX:** must be wrapped in `<span role="img" aria-label="...">` for accessibility
+- Build will fail on prettier/eslint violations — always run `npm run build` to verify

--- a/content/blog/first-post-2026.md
+++ b/content/blog/first-post-2026.md
@@ -9,7 +9,7 @@ Because I'm finally saying what I actually think. 👀
 
 **You know that whole, "know your strengths and weaknesses" thing?**
 Straight up, writing about Software actually scares me.
-I would hand brake and side step if I was to run it straight to writing (Imagine RunNation but for technical writing)
+I would hand brake and side step if I was to run it straight to writing (Imagine [RunNation](https://www.instagram.com/runnation/) but for technical writing)
 
 Take this:
 

--- a/content/blog/first-post-2026.md
+++ b/content/blog/first-post-2026.md
@@ -1,0 +1,53 @@
+---
+title: First Post 2026 -- Shipping Code Feels Safe, Sharing Opinions Feels Risky
+date: February 16, 2026
+tags: Personal, Career
+---
+
+Ok I'm nervous my boss might read this.
+Because I'm finally saying what I actually think. 👀
+
+**You know that whole, "know your strengths and weaknesses" thing?**
+Straight up, writing about Software actually scares me.
+I would hand brake and side step if I was to run it straight to writing (Imagine RunNation but for technical writing)
+
+Take this:
+
+Me building software at speed, writing seki code, shipping features?
+**On.** Confidence through the roof.
+
+Writing or getting asked about my honest thoughts and takes?
+**Yeah Nah.**
+
+If you've ever felt confident building but unsure explaining, then this might be for you.
+
+This series of posts will be snapshots of the journey of how
+a half-caste Samoan,
+born in Central Auckland Aotearoa NZ,
+musician (producer/DJ/radio host) turned Software Engineer at 30,
+now a Dad,
+recently bestowed as Matai for my family,
+is getting better at putting full, honest thoughts on paper and out there to you.
+
+My biggest strengths lie in grinding.
+Teaching myself through tinkering.
+Staying curious into late nights.
+Sniffing out what's wrong or missing.
+Being clear about what I like vs what I don't.
+
+I learned that all from making music and transferred to software.
+
+**But when it comes to technical opinions? I freeze.**
+
+But this is part of being a great Engineer. You don't just ship. You explain *why*. You defend *why*. You question *why not*.
+Shipping code feels safe to me.
+Sharing opinions about software feels risky.
+
+So here's the goal:
+**1 post a week until my birthday in April.**
+
+**7 posts. 2 rules:**
+1. Make 7 posts.
+2. Make the last one better than the first.
+
+Let me know, does this count as 1/7? Or is this the prequel?

--- a/content/blog/first-post-2026.md
+++ b/content/blog/first-post-2026.md
@@ -43,8 +43,9 @@ But this is part of being a great Engineer. You don't just ship. You explain *wh
 Shipping code feels safe to me.
 Sharing opinions about software feels risky.
 
-So here's the goal:
-**1 post a week until my birthday in April.**
+---
+
+So here's the goal -- **1 post a week until my birthday in April.**
 
 **7 posts. 2 rules:**
 1. Make 7 posts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react": "18.2",
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "typescript": "^5.9.3"
       },
@@ -2732,6 +2733,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -4040,6 +4054,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "18.2",
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "typescript": "^5.9.3"
   },

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -20,6 +20,18 @@ const Blog: FunctionComponent = () => {
 						<li className="py-2 text-lg">
 							<Link
 								className="hover:underline py-2 font-bold"
+								href="/blog/first-post-2026"
+							>
+								First Post 2026 — Shipping Code Feels Safe, Sharing
+								Opinions Feels Risky
+							</Link>
+							<p className="text-base">
+								7 posts. 2 rules. Let&apos;s go.
+							</p>
+						</li>
+						<li className="py-2 text-lg">
+							<Link
+								className="hover:underline py-2 font-bold"
 								href="/blog/malo-lava-lets-build-with-cursor"
 							>
 								Malo lava, let&apos;s build with Cursor — AI Code Editor{' '}

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -18,16 +18,10 @@ const Blog: FunctionComponent = () => {
 				<div>
 					<ul className="py-2 list-disc">
 						<li className="py-2 text-lg">
-							<Link
-								className="hover:underline py-2 font-bold"
-								href="/blog/first-post-2026"
-							>
-								First Post 2026 — Shipping Code Feels Safe, Sharing
-								Opinions Feels Risky
+							<Link className="hover:underline py-2 font-bold" href="/blog/first-post-2026">
+								First Post 2026 — Shipping Code Feels Safe, Sharing Opinions Feels Risky
 							</Link>
-							<p className="text-base">
-								7 posts. 2 rules. Let&apos;s go.
-							</p>
+							<p className="text-base">7 posts. 2 rules. Let&apos;s go.</p>
 						</li>
 						<li className="py-2 text-lg">
 							<Link

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -96,7 +96,9 @@ export default function BlogPost({ title, date, tags, content }: BlogPostProps):
 								{tags.map((tag) => (
 									<span
 										key={tag}
-										className={`text-xs font-medium px-2 py-0.5 rounded-full ${tagColors[tag] || defaultTagColor}`}
+										className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+											tagColors[tag] || defaultTagColor
+										}`}
 									>
 										{tag}
 									</span>

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -12,8 +12,18 @@ import { ReactNode } from 'react'
 interface BlogPostProps {
 	title: string
 	date: string
+	tags: string[]
 	content: string
 }
+
+const tagColors: Record<string, string> = {
+	AI: 'bg-purple-100 text-purple-700',
+	ChatGPT: 'bg-green-100 text-green-700',
+	Personal: 'bg-blue-100 text-blue-700',
+	Career: 'bg-amber-100 text-amber-700',
+}
+
+const defaultTagColor = 'bg-gray-100 text-gray-700'
 
 interface ChildrenProps {
 	children?: ReactNode
@@ -67,7 +77,7 @@ const markdownComponents: Record<string, any> = {
 	strong: ({ children }: ChildrenProps) => <strong className="font-bold">{children}</strong>,
 }
 
-export default function BlogPost({ title, date, content }: BlogPostProps): JSX.Element {
+export default function BlogPost({ title, date, tags, content }: BlogPostProps): JSX.Element {
 	return (
 		<>
 			<Head>
@@ -79,7 +89,21 @@ export default function BlogPost({ title, date, content }: BlogPostProps): JSX.E
 				</Link>
 				<article className="mt-6">
 					<h1 className="text-3xl font-bold mb-1">{title}</h1>
-					<p className="text-sm text-gray-400 mb-8">{date}</p>
+					<div className="flex items-center gap-3 mb-8">
+						<p className="text-sm text-gray-400">{date}</p>
+						{tags.length > 0 && (
+							<div className="flex gap-2">
+								{tags.map((tag) => (
+									<span
+										key={tag}
+										className={`text-xs font-medium px-2 py-0.5 rounded-full ${tagColors[tag] || defaultTagColor}`}
+									>
+										{tag}
+									</span>
+								))}
+							</div>
+						)}
+					</div>
 					<ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={markdownComponents}>
 						{content}
 					</ReactMarkdown>
@@ -104,6 +128,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 	const frontmatterMatch = raw.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/)
 	let title = slug
 	let date = ''
+	let tags: string[] = []
 	let content = raw
 
 	if (frontmatterMatch) {
@@ -111,9 +136,11 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 		content = frontmatterMatch[2]
 		const titleMatch = frontmatter.match(/^title:\s*"?(.+?)"?\s*$/m)
 		const dateMatch = frontmatter.match(/^date:\s*(.+)$/m)
+		const tagsMatch = frontmatter.match(/^tags:\s*(.+)$/m)
 		if (titleMatch) title = titleMatch[1]
 		if (dateMatch) date = dateMatch[1]
+		if (tagsMatch) tags = tagsMatch[1].split(',').map((t) => t.trim())
 	}
 
-	return { props: { title, date, content } }
+	return { props: { title, date, tags, content } }
 }

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -6,6 +6,7 @@ import Head from 'next/head'
 import Link from 'next/link'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import remarkBreaks from 'remark-breaks'
 import { ReactNode } from 'react'
 
 interface BlogPostProps {
@@ -72,14 +73,14 @@ export default function BlogPost({ title, date, content }: BlogPostProps): JSX.E
 			<Head>
 				<title>{title} | Tausani</title>
 			</Head>
-			<main className="max-w-xl mx-auto px-8 pt-10 pb-16 text-gray-700 font-sans">
+			<main className="max-w-3xl mx-auto px-8 pt-10 pb-16 text-gray-700 font-sans">
 				<Link href="/" className="text-sm text-gray-500 hover:underline">
 					&larr; Back home
 				</Link>
 				<article className="mt-6">
 					<h1 className="text-3xl font-bold mb-1">{title}</h1>
 					<p className="text-sm text-gray-400 mb-8">{date}</p>
-					<ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+					<ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={markdownComponents}>
 						{content}
 					</ReactMarkdown>
 				</article>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1578,6 +1578,14 @@ mdast-util-mdxjs-esm@^2.0.0:
     mdast-util-from-markdown "^2.0.0"
     mdast-util-to-markdown "^2.0.0"
 
+mdast-util-newline-to-break@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz"
+  integrity sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-find-and-replace "^3.0.0"
+
 mdast-util-phrasing@^4.0.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz"
@@ -2296,6 +2304,15 @@ regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
+
+remark-breaks@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz"
+  integrity sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-newline-to-break "^2.0.0"
+    unified "^11.0.0"
 
 remark-gfm@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
## Summary
- Add new blog post: "Shipping Code Feels Safe, Sharing Opinions Feels Risky"
- Add `remark-breaks` plugin so markdown line breaks render properly
- Widen blog post layout from `max-w-xl` to `max-w-3xl`
- Parse and display frontmatter tags as coloured pills on blog posts
- Link RunNation to their Instagram

## Test plan
- [x] Verify new post renders at `/blog/first-post-2026`
- [x] Check line breaks display correctly in the post
- [x] Confirm tag pills show with correct colours (Personal = blue, Career = amber)
- [x] Verify older posts also display their tags
- [x] Check blog listing page shows the new post at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)