### PR TITLE
Update styling

### DIFF
--- a/public/tools/beat-rizz/css/styles.css
+++ b/public/tools/beat-rizz/css/styles.css
@@ -191,6 +191,59 @@ body.force-landscape {
   to   { opacity: 1; transform: translateY(0); }
 }
 
+.start-keys {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  animation: fade-up 0.8s ease 0.6s both;
+}
+
+.start-keys-label {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 0.6rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.2);
+}
+
+.start-keys-inner {
+  display: flex;
+  gap: 16px;
+}
+
+.start-key-row {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.start-key-row kbd {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-bottom-width: 2px;
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  font-family: inherit;
+}
+
+.start-key-row span {
+  font-size: 0.55rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.3);
+}
+
 /* ─── Swipe hint (one-time, shown after start) ────────────── */
 
 #swipe-hint {

--- a/public/tools/beat-rizz/index.html
+++ b/public/tools/beat-rizz/index.html
@@ -51,6 +51,15 @@
         <span class="start-tap-text">tap to start</span>
       </div>
       <p class="start-hint">tap the pads · jam to curated tracks or paste your own · swipe to switch</p>
+      <div class="start-keys">
+        <p class="start-keys-label">if not on mobile</p>
+        <div class="start-keys-inner">
+          <div class="start-key-row"><kbd>D</kbd><span>kick</span></div>
+          <div class="start-key-row"><kbd>F</kbd><span>clap</span></div>
+          <div class="start-key-row"><kbd>J</kbd><span>snare</span></div>
+          <div class="start-key-row"><kbd>K</kbd><span>hihat</span></div>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/public/tools/beat-rizz/js/main.js
+++ b/public/tools/beat-rizz/js/main.js
@@ -46,6 +46,7 @@ function submitUrl() {
   if (ok) {
     ytInput.value = '';
     closeLoadPanel();
+    dismissSwipeHint();
   } else {
     ytError.hidden = false;
   }
@@ -80,6 +81,7 @@ function dismissSwipeHint() {
 
 function commitSwipe(dir) {
   dismissSwipeHint();
+  closeLoadPanel();
 
   const vh = window.innerHeight;
   const outY = dir === 'next' ? -vh : vh;

--- a/public/tools/beat-rizz/js/pads.js
+++ b/public/tools/beat-rizz/js/pads.js
@@ -1,10 +1,10 @@
 import { playSound } from './audio/synth.js';
 
 const KEY_MAP = {
-  q: 'kick',
-  w: 'clap',
-  e: 'snare',
-  r: 'hihat',
+  d: 'kick',
+  f: 'clap',
+  j: 'snare',
+  k: 'hihat',
 };
 
 function triggerPad(el) {


### PR DESCRIPTION
## Summary
- Adds BeatRizz (formerly live-drumz) — a mobile-first drum machine that layers virtual pads over any YouTube playlist
- Renamed tool folder and route from `live-drumz` to `beat-rizz`
- New branding: "Beat Rizz" wordmark on start screen and in top-left of app, with "created by tausani.net" link
- Start screen shows keyboard shortcuts (D/F/J/K) with "if not on mobile" label
- Defaults YouTube playback quality to 1080p
- Swipe hint dismisses when user loads a custom URL; URL panel closes on first swipe
- Added `next.config.js` with rewrite for local dev compatibility

## Test plan
- [ ] Visit `/tools/beat-rizz/` and verify start screen shows BeatRizz wordmark, hint text, and keyboard guide
- [ ] Tap/click to start — URL panel opens, swipe hint appears
- [ ] Paste a YouTube URL and hit Go — swipe hint dismisses, panel closes
- [ ] Swipe to change track — URL panel closes if open
- [ ] Test keyboard pads: D (kick), F (clap), J (snare), K (hihat)
- [ ] Check "created by tausani.net" link in bottom-right opens tausani.net
- [ ] Verify projects page shows BeatRizz with updated description and correct link

🤖 Generated with [Claude Code](https://claude.com/claude-code)