### PR TITLE
Enhance RSS feed with full content, images, and HTML formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react": "18.2",
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0",
+        "rehype-stringify": "^10.0.1",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "typescript": "^5.9.3"
@@ -2073,6 +2074,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -2127,6 +2151,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ignore": {
@@ -4092,6 +4126,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/rehype-stringify": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-breaks": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "18.2",
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
+    "rehype-stringify": "^10.0.1",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "typescript": "^5.9.3"

--- a/scripts/generate-rss.mjs
+++ b/scripts/generate-rss.mjs
@@ -1,5 +1,11 @@
 import fs from 'fs'
 import path from 'path'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkGfm from 'remark-gfm'
+import remarkBreaks from 'remark-breaks'
+import remarkRehype from 'remark-rehype'
+import rehypeStringify from 'rehype-stringify'
 
 const SITE_URL = 'https://tausani.net'
 const SITE_TITLE = 'Tausani Ah Chong'
@@ -48,6 +54,30 @@ function getDescription(content) {
 	return meaningful.length > 200 ? meaningful.slice(0, 200) + '...' : meaningful
 }
 
+async function markdownToHtml(markdown) {
+	const result = await unified()
+		.use(remarkParse)
+		.use(remarkGfm)
+		.use(remarkBreaks)
+		.use(remarkRehype, { allowDangerousHtml: true })
+		.use(rehypeStringify, { allowDangerousHtml: true })
+		.process(markdown)
+	return String(result)
+}
+
+function absolutizeUrls(html) {
+	return html
+		.replace(/(<img\s[^>]*src=")\//g, `$1${SITE_URL}/`)
+		.replace(/(<a\s[^>]*href=")\//g, `$1${SITE_URL}/`)
+}
+
+function extractFirstImage(content) {
+	const match = content.match(/!\[.*?\]\(([^)]+)\)/)
+	if (!match) return null
+	const src = match[1]
+	return src.startsWith('/') ? `${SITE_URL}${src}` : src
+}
+
 const blogDir = path.join(process.cwd(), 'content/blog')
 const files = fs.readdirSync(blogDir).filter((f) => f.endsWith('.md'))
 
@@ -58,25 +88,40 @@ const posts = files
 	})
 	.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
 
-const items = posts
-	.map((post) => {
+const items = await Promise.all(
+	posts.map(async (post) => {
 		const link = `${SITE_URL}/blog/${post.slug}/`
 		const pubDate = new Date(post.date).toUTCString()
 		const description = escapeXml(getDescription(post.content))
+		const rawHtml = await markdownToHtml(post.content)
+		const html = absolutizeUrls(rawHtml)
+		const firstImage = extractFirstImage(post.content)
+
+		let mediaElements = ''
+		if (firstImage) {
+			mediaElements = `
+      <media:content url="${firstImage}" medium="image"/>
+      <media:thumbnail url="${firstImage}"/>`
+		}
+
 		return `    <item>
       <title>${escapeXml(post.title)}</title>
       <link>${link}</link>
       <guid>${link}</guid>
       <pubDate>${pubDate}</pubDate>
       <description>${description}</description>
+      <content:encoded><![CDATA[${html}]]></content:encoded>${mediaElements}
     </item>`
 	})
-	.join('\n')
+)
 
-const lastBuildDate = posts.length > 0 ? new Date(posts[0].date).toUTCString() : new Date().toUTCString()
+const itemsStr = items.join('\n')
+
+const lastBuildDate =
+	posts.length > 0 ? new Date(posts[0].date).toUTCString() : new Date().toUTCString()
 
 const rss = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:media="http://search.yahoo.com/mrss/">
   <channel>
     <title>${escapeXml(SITE_TITLE)}</title>
     <link>${SITE_URL}</link>
@@ -84,7 +129,12 @@ const rss = `<?xml version="1.0" encoding="UTF-8"?>
     <language>en</language>
     <lastBuildDate>${lastBuildDate}</lastBuildDate>
     <atom:link href="${SITE_URL}/feed.xml" rel="self" type="application/rss+xml"/>
-${items}
+    <image>
+      <url>${SITE_URL}/sani-headshot.jpg</url>
+      <title>${escapeXml(SITE_TITLE)}</title>
+      <link>${SITE_URL}</link>
+    </image>
+${itemsStr}
   </channel>
 </rss>
 `


### PR DESCRIPTION
## Summary

- Convert markdown to HTML in the RSS feed using the unified/remark/rehype pipeline (same rendering as the blog) so feed readers display proper formatting
- Include full blog post content via `<content:encoded>` instead of truncated 200-character descriptions
- Extract first image from each post as `<media:thumbnail>` for Feedly post thumbnails
- Add channel-level `<image>` using author headshot for feed branding
- Convert all image URLs to absolute paths so they load in feed readers

## Test plan

- [ ] Run `node scripts/generate-rss.mjs` and verify `public/feed.xml` has `<content:encoded>` with full HTML for each post
- [ ] Verify image URLs in the feed are absolute (`https://tausani.net/...`)
- [ ] Verify `<media:thumbnail>` is present for posts with images (5 of 7)
- [ ] Add feed to Feedly and confirm images and formatting display correctly
- [ ] Run `npm run build` to confirm the full pipeline works

https://claude.ai/code/session_018LMvaMSudgxvfdvfv1N53z